### PR TITLE
Versioning

### DIFF
--- a/app/controllers/base.py
+++ b/app/controllers/base.py
@@ -5,6 +5,7 @@ Base controller for html pages.
 import os
 
 from jinja2 import FileSystemLoader, Environment
+from app.models.version import get_version
 
 
 class BaseController:
@@ -30,9 +31,11 @@ class BaseController:
         renders arguments to jinja views.
         """
         template = self.template_env.get_template(template_path)
+        version = get_version()
 
         return template.render(
             title=self.title,
             menu=self.menu,
+            version=version,
             **arguments,
         )

--- a/app/models/version.py
+++ b/app/models/version.py
@@ -1,0 +1,15 @@
+"""
+Helpers for semantic versioning
+"""
+
+from sys import argv
+
+
+def get_version() -> str:
+    """
+    Tries to grab the version from the CLI argument.
+    """
+    if len(argv) > 1:
+        return argv[1]
+
+    return '@dev'

--- a/app/views/header.html.j2
+++ b/app/views/header.html.j2
@@ -3,7 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Telco Oběžník</title>
     <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;700&display=swap" rel="stylesheet">
-    <link href="css/style-main.min.css" rel="stylesheet">
+    <link href="css/style-main.min.css?{{ version }}" rel="stylesheet">
     <script src="https://kit.fontawesome.com/54b604a66f.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-142122726-1"></script>
@@ -12,6 +12,8 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'UA-142122726-1');
+      gtag('config', 'UA-142122726-1', {
+        appVersion: '{{ version }}',
+    });
     </script>
 </head>


### PR DESCRIPTION
Apply the version number to static assets to avoid browser caching. Each version will generate a unique URL to always download the latest one.